### PR TITLE
on delete famMember, remove their content/lovebanks

### DIFF
--- a/modules/familyMembers/resolvers/mutations.js
+++ b/modules/familyMembers/resolvers/mutations.js
@@ -2,6 +2,7 @@ const FamilyMember = require("../../../models/FamilyMember");
 const { UserInputError } = require("apollo-server");
 const Kid = require("../../../models/Kid");
 const checkAuth = require("../../../utils/check-auth");
+const LoveBank = require("../../../models/LoveBank");
 
 const addMember = async (_, { kidId, relation, notification }, context) => {
   const user = checkAuth(context);
@@ -35,20 +36,51 @@ const addMember = async (_, { kidId, relation, notification }, context) => {
   }
 };
 
-const deleteMember = async (
-  _,
-  {  _id },
-  context
-) => {
+const deleteMember = async (_, { _id }, context) => {
   const user = checkAuth(context);
-  const familyMember = await FamilyMember.findOne({_id: _id});
-  console.log("mutation", familyMember)
+  const familyMember = await FamilyMember.findOne({ _id: _id });
+  const famMemUserId = familyMember.userId;
+
+  const lovebank = await LoveBank.find({
+    kidId: familyMember.kid,
+  });
+
+  //filter out the correct lovebank specific to familymember
+  const correctLoveBanks = lovebank.filter((item) => {
+    if (famMemUserId == item.userId) {
+      return true;
+    } else {
+      return false;
+    }
+  });
+
   try {
     if (familyMember) {
-      console.log("mutation familyMember exists")
-      await FamilyMember.deleteOne({ _id: _id })
-      return `${familyMember._id} deleted!`
-      return 
+      console.log("mutation familyMember exists");
+
+      //delete family members content from lovebank
+      const functionWithPromise = (item) => {
+        return Promise.resolve("ok");
+      };
+
+      const anAsyncFunction = async (item) => {
+        await LoveBank.findByIdAndDelete(item._id);
+        return functionWithPromise(item);
+      };
+
+      const getData = async () => {
+        return Promise.all(
+          correctLoveBanks.map((item) => {
+            anAsyncFunction(item);
+          })
+        );
+      };
+
+      getData();
+
+      //delete familyMember
+      await FamilyMember.deleteOne({ _id: _id });
+      return `${familyMember._id} deleted!`;
     } else {
       throw new UserInputError("FamilyMember not found");
     }


### PR DESCRIPTION
Deleting not only the familyMember but also it's content from the loveBank.

- On delete member we pass in id and get the family member. (including family member's userId and the kidId)
- Search for lovebanks with kidId
- create new array with filtered lovebanks (where item.id === family member's userid)
- write a function with a promise so I can map over the new array and await LoveBank.findByIdAndDelete()
- then continue and delete the familyMember .